### PR TITLE
Improve admin navigation, search, and table usability

### DIFF
--- a/admin/css/admin.snicker.css
+++ b/admin/css/admin.snicker.css
@@ -19,6 +19,47 @@
 }
 /* @end GENERAL */
 
+/* @start Admin Search */
+.snicker-search-row {
+    --snicker-search-control-size: 3.25rem;
+}
+
+.snicker-search-row .snicker-search-control {
+    min-width: 320px;
+    height: var(--snicker-search-control-size) !important;
+    min-height: var(--snicker-search-control-size);
+    box-sizing: border-box;
+}
+
+.snicker-search-row .snicker-search-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--snicker-search-control-size);
+    height: var(--snicker-search-control-size) !important;
+    min-height: var(--snicker-search-control-size);
+    padding: 0 !important;
+    line-height: 1;
+    box-sizing: border-box;
+}
+
+.snicker-search-row .snicker-search-button .fa {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1em;
+    height: 1em;
+    margin-right: 0 !important;
+    line-height: 1;
+}
+/* @end Admin Search */
+
+/* @start Admin Tables */
+.tab-content .contentTools a {
+    white-space: nowrap;
+}
+/* @end Admin Tables */
+
 /* @start Admin Navigation */
 .nav.nav-pills .snicker-nav-link {
     color: #343a40;

--- a/admin/index-comments.php
+++ b/admin/index-comments.php
@@ -20,11 +20,12 @@ $limit = $SnickerPlugin->getValue("frontend_per_page");
 if ($limit === 0) {
     $limit = 15;
 }
-$current = isset($_GET["tab"]) ? $_GET["tab"] : "pending";
+$current = isset($current) ? $current : (isset($_GET["tab"]) ? $_GET["tab"] : "pending");
+$commentSearch = isset($_GET["commentSearch"]) ? trim($_GET["commentSearch"]) : "";
 
 // Get View
 $view = "index";
-if (isset($_GET["view"]) && in_array($_GET["view"], array("search", "single", "uuid", "user"))) {
+if (isset($_GET["view"]) && in_array($_GET["view"], array("single", "uuid", "user"))) {
     $view = $current = $_GET["view"];
     $tabs = array($view);
 } else {
@@ -40,12 +41,13 @@ foreach ($tabs as $status) {
     }
 
     // Get Comments
-    if ($view === "index") {
+    $isFiltered = ($view === "index" && $current === $status && $commentSearch !== "");
+    if ($isFiltered) {
+        $comments = $SnickerIndex->searchComments($commentSearch, $page, $limit, $status);
+        $total = count($SnickerIndex->searchComments($commentSearch, 1, -1, $status));
+    } else if ($view === "index") {
         $comments = $SnickerIndex->getList($status, $page, $limit);
         $total = $SnickerIndex->count($status);
-    } else if ($view === "search") {
-        $comments = $SnickerIndex->searchComments(isset($_GET["search"]) ? $_GET["search"] : "");
-        $total = count($comments);
     } else if ($view === "single") {
         $comments = $SnickerIndex->getListByParent(isset($_GET["single"]) ? $_GET["single"] : "");
         $total = count($comments);
@@ -58,74 +60,72 @@ foreach ($tabs as $status) {
     }
 
     // Render Tab Content
-    $link = DOMAIN_ADMIN . "snicker?page=%d&tab={$status}#{$status}";
+    $link = DOMAIN_ADMIN . "snicker?page=%d&tab={$status}";
+    if ($isFiltered) {
+        $link .= "&commentSearch=" . urlencode($commentSearch);
+    }
     ?>
-    <div id="snicker-<?php echo $status; ?>" class="tab-pane <?php echo ($current === $status) ? "active" : ""; ?>">
-        <div class="card shadow-sm" style="margin: 1.5rem 0;">
-            <div class="card-body">
-                <div class="row">
-                    <form class="col-sm-6" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker">
-                        <div class="form-row align-items-center">
-                            <div class="col-sm-8">
-                                <?php $search = isset($_GET["search"]) ? $_GET["search"] : ""; ?>
-                                <input type="text" name="search" value="<?php echo $search; ?>" class="form-control" placeholder="<?php sn_e("Comment Title or Excerpt"); ?>" />
-                            </div>
-                            <div class="col-sm-4">
-                                <button class="btn btn-primary" name="view" value="search"><?php sn_e("Search Comments"); ?></button>
-                            </div>
-                        </div>
-                    </form>
+    <div id="snicker-<?php echo $status; ?>" class="tab-pane <?php echo ($current === $status) ? "show active" : ""; ?>" role="tabpanel">
+        <div class="snicker-search-row d-flex align-items-center flex-wrap mt-4 mb-4">
+            <form class="form-inline flex-nowrap mr-3 mb-2" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker">
+                <input type="hidden" name="tab" value="<?php echo $status; ?>" />
+                <input type="text" name="commentSearch" value="<?php echo ($current === $status) ? Sanitize::html($commentSearch) : ""; ?>" class="snicker-search-control form-control mr-2" placeholder="<?php sn_e("Comment Title or Excerpt"); ?>" />
+                <?php if ($isFiltered) { ?>
+                    <a href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=<?php echo $status; ?>" class="snicker-search-button btn btn-secondary mr-2" title="<?php sn_e("Clear"); ?>" aria-label="<?php sn_e("Clear"); ?>">
+                        <span class="fa fa-times"></span>
+                    </a>
+                <?php } ?>
+                <button class="snicker-search-button btn btn-primary" type="submit" title="<?php sn_e("Search Comments"); ?>" aria-label="<?php sn_e("Search Comments"); ?>">
+                    <span class="fa fa-search"></span>
+                </button>
+            </form>
 
-                    <div class="col-sm-6 text-right">
-                        <?php if ($total > $limit) { ?>
-                            <div class="btn-group btn-group-pagination">
-                                <?php if ($page <= 1) { ?>
-                                    <span class="btn btn-secondary disabled">&laquo;</span>
-                                    <span class="btn btn-secondary disabled">&lsaquo;</span>
-                                <?php } else { ?>
-                                    <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
-                                    <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
-                                <?php } ?>
-                                <?php if (($page * $limit) < $total) { ?>
-                                    <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
-                                    <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
-                                <?php } else { ?>
-                                    <span class="btn btn-secondary disabled">&rsaquo;</span>
-                                    <span class="btn btn-secondary disabled">&raquo;</span>
-                                <?php } ?>
-                            </div>
+            <div class="ml-auto mb-2">
+                <?php if ($limit !== -1 && $total > $limit) { ?>
+                    <div class="btn-group btn-group-pagination">
+                        <?php if ($page <= 1) { ?>
+                            <span class="btn btn-secondary disabled">&laquo;</span>
+                            <span class="btn btn-secondary disabled">&lsaquo;</span>
+                        <?php } else { ?>
+                            <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
+                            <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
+                        <?php } ?>
+                        <?php if (($page * $limit) < $total) { ?>
+                            <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
+                            <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
+                        <?php } else { ?>
+                            <span class="btn btn-secondary disabled">&rsaquo;</span>
+                            <span class="btn btn-secondary disabled">&raquo;</span>
                         <?php } ?>
                     </div>
-                </div>
+                <?php } ?>
             </div>
         </div>
 
         <?php /* No Comments available */ ?>
         <?php if (count($comments) < 1) { ?>
-            <div class="row justify-content-md-center">
-                <div class="col-sm-6">
-                    <div class="card w-100 shadow-sm bg-light">
-                        <div class="card-body text-center p-4"><i><?php sn_e("No Comments available"); ?></i></div>
-                    </div>
-                </div>
-            </div>
+            <p class="mt-4 text-muted">
+                <?php if ($isFiltered) { ?>
+                    <?php sn_e("There are no %s comments matching \"%s\".", array(strtolower($strings[$status]), Sanitize::html($commentSearch))); ?>
+                <?php } else { ?>
+                    <?php sn_e("There are no %s comments at this moment.", array(strtolower($strings[$status]))); ?>
+                <?php } ?>
+            </p>
         </div>
         <?php continue; ?>
     <?php } ?>
 
     <?php /* Comments Table */ ?>
     <?php $link = DOMAIN_ADMIN . "snicker?action=snicker&snicker=%s&uid=%s&status=%s&tokenCSRF=" . $security->getTokenCSRF(); ?>
-    <table class="table table-bordered table-hover-light shadow-sm mt-3">
-        <?php foreach (array("thead", "tfoot") as $tag) { ?>
-            <<?php echo $tag; ?>>
-                <tr class="thead-light">
-                    <th width="56%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("Comment"); ?></th>
-                    <th width="22%" class="border-0 p-3 text-uppercase text-muted text-center"><?php sn_e("Author"); ?></th>
-                    <th width="22%" class="border-0 p-3 text-uppercase text-muted text-center"><?php sn_e("Actions"); ?></th>
-                </tr>
-            </<?php echo $tag; ?>>
-        <?php } ?>
-        <tbody class="shadow-sm-both">
+    <table class="table mt-3">
+        <thead>
+            <tr>
+                <th class="border-0" scope="col"><?php sn_e("Comment"); ?></th>
+                <th class="border-0 d-none d-lg-table-cell" scope="col"><?php sn_e("Author"); ?></th>
+                <th class="border-0 text-center d-sm-table-cell" scope="col"><?php sn_e("Actions"); ?></th>
+            </tr>
+        </thead>
+        <tbody>
             <?php foreach ($comments as $uid) { ?>
                 <?php
                 $data = $SnickerIndex->getComment($uid, $status);
@@ -135,51 +135,52 @@ foreach ($tabs as $status) {
                 $user = $SnickerUsers->getByString($data["author"]);
                 ?>
                 <tr>
-                    <td class="pt-3 pb-3 pl-3 pr-3">
-                        <?php
-                        if ($SnickerPlugin->getValue("comment_title") !== "disabled" && !empty($data["title"])) {
-                            echo '<b class="d-inline-block">' . $data["title"] . '</b>';
-                        }
-                        echo '<p class="text-muted m-0" style="font-size:12px;">' . (isset($data["excerpt"]) ? $data["excerpt"] : "") . '</p>';
-                        if (!empty($data["parent_uid"]) && $SnickerIndex->exists($data["parent_uid"]) && $view !== "single") {
+                    <td class="pt-3">
+                        <div>
+                            <a style="font-size: 1.1em" href="<?php echo DOMAIN_ADMIN . "snicker/edit/?uid=" . $uid; ?>">
+                                <?php
+                                if ($SnickerPlugin->getValue("comment_title") !== "disabled" && !empty($data["title"])) {
+                                    echo $data["title"];
+                                } else {
+                                    echo sn__("Comment");
+                                }
+                                ?>
+                            </a>
+                        </div>
+                        <div>
+                            <p style="font-size: 0.8em" class="m-0 text-muted">
+                                <?php echo isset($data["excerpt"]) ? $data["excerpt"] : ""; ?>
+                            </p>
+                        </div>
+                        <?php if (!empty($data["parent_uid"]) && $SnickerIndex->exists($data["parent_uid"]) && $view !== "single") { ?>
+                            <?php
                             $reply = DOMAIN_ADMIN . "snicker?view=single&single={$uid}";
                             $reply = '<a href="' . $reply . '" title="' . sn__("Show all replies") . '">' . $SnickerIndex->getComment($data["parent_uid"])["title"] . '</a>';
-                            echo "<div class='text-muted mt-1' style='font-size:12px;'>" . sn__("Reply To") . ": " . $reply . "</div>";
-                        }
-                        ?>
+                            ?>
+                            <div class="text-muted mt-1" style="font-size: 0.8em;"><?php echo sn__("Reply To") . ": " . $reply; ?></div>
+                        <?php } ?>
                     </td>
-                    <td class="align-middle pt-2 pb-2 pl-3 pr-3">
+                    <td class="pt-3 d-none d-lg-table-cell">
                         <span class="d-inline-block"><?php echo $user["username"]; ?></span>
-                        <small class='d-block'><?php echo $user["email"]; ?></small>
+                        <p style="font-size: 0.8em" class="m-0 text-muted"><?php echo $user["email"]; ?></p>
                     </td>
-                    <td class="text-center align-middle pt-2 pb-2 pl-1 pr-1">
-                        <div class="btn-group">
-                            <button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
-                                <?php sn_e("Change"); ?>
-                            </button>
-                            <div class="dropdown-menu dropdown-menu-right">
-                                <a class="dropdown-item text-primary" href="<?php echo DOMAIN_ADMIN . "snicker/edit/?uid=" . $uid; ?>"><?php sn_e("Edit Comment"); ?></a>
-                                <a class="dropdown-item text-danger" href="<?php printf($link, "delete", $uid, "delete"); ?>"><?php sn_e("Delete Comment"); ?></a>
-                                <div class="dropdown-divider"></div>
-
-                                <?php if ($status !== "approved") { ?>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "approved"); ?>"><?php sn_e("Approve Comment"); ?></a>
-                                <?php } ?>
-                                <?php if ($status !== "rejected") { ?>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "rejected"); ?>"><?php sn_e("Reject Comment"); ?></a>
-                                <?php } ?>
-                                <?php if ($status !== "spam") { ?>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "spam"); ?>"><?php sn_e("Mark as Spam"); ?></a>
-                                <?php } ?>
-                                <?php if ($status !== "pending") { ?>
-                                    <div class="dropdown-divider"></div>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "pending"); ?>"><?php sn_e("Back to Pending"); ?></a>
-                                <?php } ?>
-                            </div>
-                        </div>
-
+                    <td class="contentTools pt-3 text-center d-sm-table-cell">
                         <?php $page = new Page($pages->getByUUID($data["page_uuid"])); ?>
-                        <a href="<?php echo $page->permalink(); ?>#comment-<?php echo $uid; ?>" class="btn btn-outline-primary btn-sm" target="_blank"><?php sn_e("View"); ?></a>
+                        <a class="text-secondary d-none d-md-inline" href="<?php echo $page->permalink(); ?>#comment-<?php echo $uid; ?>" target="_blank"><i class="fa fa-desktop"></i><?php sn_e("View"); ?></a>
+                        <a class="text-secondary d-none d-md-inline ml-2" href="<?php echo DOMAIN_ADMIN . "snicker/edit/?uid=" . $uid; ?>"><i class="fa fa-edit"></i><?php sn_e("Edit"); ?></a>
+                        <?php if ($status !== "approved") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "approved"); ?>"><i class="fa fa-check"></i><?php sn_e("Approve"); ?></a>
+                        <?php } ?>
+                        <?php if ($status !== "rejected") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "rejected"); ?>"><i class="fa fa-ban"></i><?php sn_e("Reject"); ?></a>
+                        <?php } ?>
+                        <?php if ($status !== "spam") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "spam"); ?>"><i class="fa fa-warning"></i><?php sn_e("Spam"); ?></a>
+                        <?php } ?>
+                        <?php if ($status !== "pending") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "pending"); ?>"><i class="fa fa-inbox"></i><?php sn_e("Pending"); ?></a>
+                        <?php } ?>
+                        <a class="text-danger d-block d-lg-inline ml-lg-2" href="<?php printf($link, "delete", $uid, "delete"); ?>"><i class="fa fa-trash"></i><?php sn_e("Delete"); ?></a>
                     </td>
                 </tr>
             <?php } ?>

--- a/admin/index-config.php
+++ b/admin/index-config.php
@@ -18,8 +18,8 @@ global $L, $login, $pages, $security, $Snicker, $SnickerPlugin;
 $static = $pages->getStaticDB(false);
 
 ?>
-<div id="snicker-configure" class="tab-pane">
-    <form method="post" action="<?php echo HTML_PATH_ADMIN_ROOT; ?>snicker#configure">
+<div id="snicker-configure" class="tab-pane <?php echo (isset($current) && $current === "configure") ? "show active" : ""; ?>" role="tabpanel">
+    <form method="post" action="<?php echo HTML_PATH_ADMIN_ROOT; ?>snicker?tab=configure">
         <div class="card shadow-sm" style="margin: 1.5rem 0;">
             <div class="card-body">
                 <div class="row">

--- a/admin/index-users.php
+++ b/admin/index-users.php
@@ -18,113 +18,108 @@ global $SnickerUsers;
 $page = max((isset($_GET["page"]) ? (int) $_GET["page"] : 1), 1);
 $limit = sn_config("frontend_per_page");
 $total = count($SnickerUsers->db);
+$search = "";
+$isFiltered = (isset($current) && $current === "users" && isset($_GET["userSearch"]) && trim($_GET["userSearch"]) !== "");
 
 // Get Users
-$search = null;
-if (isset($_GET["view"]) && $_GET["view"] === "users") {
-    $page = 1;
-    $limit = -1;
-    $search = isset($_GET["search"]) ? $_GET["search"] : null;
+if ($isFiltered) {
+    $search = trim($_GET["userSearch"]);
+    $total = count($SnickerUsers->getList($search, 1, -1));
 }
-$users = $SnickerUsers->getList($search, $page, $limit);
+$users = $SnickerUsers->getList($isFiltered ? $search : null, $page, $limit);
 
 // Link
-$link = DOMAIN_ADMIN . "snicker?page=%d&tab=users#users";
+$link = DOMAIN_ADMIN . "snicker?page=%d&tab=users";
+if ($isFiltered) {
+    $link .= "&userSearch=" . urlencode($search);
+}
 
 ?>
-<div id="snicker-users" class="tab-pane">
-    <div class="card shadow-sm" style="margin: 1.5rem 0;">
-        <div class="card-body">
-            <div class="row">
-                <form class="col-sm-6" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker#users">
-                    <div class="form-row align-items-center">
-                        <div class="col-sm-8">
-                            <input type="text" name="search" value="<?php echo $search; ?>" class="form-control" placeholder="<?php sn_e("Username or eMail Address"); ?>" />
-                        </div>
-                        <div class="col-sm-4">
-                            <button class="btn btn-primary" name="view" value="users"><?php sn_e("Search Users"); ?></button>
-                        </div>
-                    </div>
-                </form>
+<div id="snicker-users" class="tab-pane <?php echo (isset($current) && $current === "users") ? "show active" : ""; ?>" role="tabpanel">
+    <div class="snicker-search-row d-flex align-items-center flex-wrap mt-4 mb-4">
+        <form class="form-inline flex-nowrap mr-3 mb-2" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker">
+            <input type="hidden" name="tab" value="users" />
+            <input type="text" name="userSearch" value="<?php echo Sanitize::html($search); ?>" class="snicker-search-control form-control mr-2" placeholder="<?php sn_e("Username or eMail Address"); ?>" />
+            <?php if ($isFiltered) { ?>
+                <a href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=users" class="snicker-search-button btn btn-secondary mr-2" title="<?php sn_e("Clear"); ?>" aria-label="<?php sn_e("Clear"); ?>">
+                    <span class="fa fa-times"></span>
+                </a>
+            <?php } ?>
+            <button class="snicker-search-button btn btn-primary" type="submit" title="<?php sn_e("Search Users"); ?>" aria-label="<?php sn_e("Search Users"); ?>">
+                <span class="fa fa-search"></span>
+            </button>
+        </form>
 
-                <div class="col-sm-6 text-right">
-                    <?php if ($total > $limit) { ?>
-                        <div class="btn-group btn-group-pagination">
-                            <?php if ($page <= 1) { ?>
-                                <span class="btn btn-secondary disabled">&laquo;</span>
-                                <span class="btn btn-secondary disabled">&lsaquo;</span>
-                            <?php } else { ?>
-                                <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
-                                <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
-                            <?php } ?>
-                            <?php if (($page * $limit) < $total) { ?>
-                                <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
-                                <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
-                            <?php } else { ?>
-                                <span class="btn btn-secondary disabled">&rsaquo;</span>
-                                <span class="btn btn-secondary disabled">&raquo;</span>
-                            <?php } ?>
-                        </div>
+        <div class="ml-auto mb-2">
+            <?php if ($limit !== -1 && $total > $limit) { ?>
+                <div class="btn-group btn-group-pagination">
+                    <?php if ($page <= 1) { ?>
+                        <span class="btn btn-secondary disabled">&laquo;</span>
+                        <span class="btn btn-secondary disabled">&lsaquo;</span>
+                    <?php } else { ?>
+                        <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
+                        <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
+                    <?php } ?>
+                    <?php if (($page * $limit) < $total) { ?>
+                        <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
+                        <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
+                    <?php } else { ?>
+                        <span class="btn btn-secondary disabled">&rsaquo;</span>
+                        <span class="btn btn-secondary disabled">&raquo;</span>
                     <?php } ?>
                 </div>
-            </div>
+            <?php } ?>
         </div>
     </div>
 
     <?php if (!$users || count($users) === 0) { ?>
-        <div class="row justify-content-md-center">
-            <div class="col-sm-6">
-                <div class="card w-100 shadow-sm bg-light">
-                    <div class="card-body text-center p-4"><i><?php sn_e("No Users available"); ?></i></div>
-                </div>
-            </div>
-        </div>
+        <?php if ($isFiltered) { ?>
+            <p class="mt-4 text-muted"><?php sn_e("There are no users matching \"%s\".", array(Sanitize::html($search))); ?></p>
+        <?php } else { ?>
+            <p class="mt-4 text-muted"><?php sn_e("There are no users at this moment."); ?></p>
+        <?php } ?>
     <?php } else { ?>
         <?php $link = DOMAIN_ADMIN . "snicker?action=snicker&snicker=users&uuid=%s&handle=%s&tokenCSRF=" . $security->getTokenCSRF(); ?>
-        <table class="table table-bordered table-hover-light shadow-sm mt-3">
-            <?php foreach (array("thead", "tfoot") as $tag) { ?>
-                <<?php echo $tag; ?>>
-                    <tr class="thead-light">
-                        <th width="38%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("Username"); ?></th>
-                        <th width="15%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("eMail"); ?></th>
-                        <th width="22%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("Comments"); ?></th>
-                        <th width="25%" class="border-0 p-3 text-uppercase text-muted text-center"><?php sn_e("Actions"); ?></th>
-                    </tr>
-                </<?php echo $tag; ?>>
-            <?php } ?>
-
-            <tbody class="shadow-sm-both">
+        <table class="table mt-3">
+            <thead>
+                <tr>
+                    <th class="border-0" scope="col"><?php sn_e("Username"); ?></th>
+                    <th class="border-0 d-none d-lg-table-cell" scope="col"><?php sn_e("eMail"); ?></th>
+                    <th class="border-0 text-center d-none d-md-table-cell" scope="col"><?php sn_e("Comments"); ?></th>
+                    <th class="border-0 text-center d-sm-table-cell" scope="col"><?php sn_e("Actions"); ?></th>
+                </tr>
+            </thead>
+            <tbody>
                 <?php foreach ($users as $uuid => $user) { ?>
                     <tr>
-                        <td class="p-3">
-                            <?php echo $user["username"]; ?>
+                        <td class="pt-3">
+                            <div>
+                                <a style="font-size: 1.1em" href="<?php echo DOMAIN_ADMIN; ?>snicker?view=user&user=<?php echo $uuid; ?>">
+                                    <?php echo $user["username"]; ?>
+                                </a>
+                            </div>
+                            <div class="d-lg-none">
+                                <p style="font-size: 0.8em" class="m-0 text-muted"><?php echo $user["email"]; ?></p>
+                            </div>
                         </td>
-                        <td class="p-3">
+                        <td class="pt-3 d-none d-lg-table-cell">
                             <?php echo $user["email"]; ?>
                         </td>
-                        <td class="text-center align-middle pt-2 pb-2 pl-1 pr-1">
+                        <td class="pt-3 text-center d-none d-md-table-cell">
                             <a href="<?php echo DOMAIN_ADMIN; ?>snicker?view=user&user=<?php echo $uuid; ?>">
                                 <?php echo count(isset($user["comments"]) ? $user["comments"] : array()); ?>
                                 <?php sn_e("Comments"); ?>
                             </a>
                         </td>
-                        <td class="text-center align-middle pt-2 pb-2 pl-1 pr-1">
-                            <div class="btn-group">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
-                                    <?php sn_e("Handle"); ?>
-                                </button>
-                                <div class="dropdown-menu dropdown-menu-right">
-                                    <a class="dropdown-item text-danger" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=true"><?php sn_e("Delete (Anonymize)"); ?></a>
-                                    <a class="dropdown-item text-danger" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=false"><?php sn_e("Delete (Completely)"); ?></a>
-                                    <div class="dropdown-divider"></div>
-
-                                    <?php if ($user["blocked"]) { ?>
-                                        <a class="dropdown-item" href="<?php printf($link, $uuid, "unblock"); ?>"><?php sn_e("Unblock User"); ?></a>
-                                    <?php } else { ?>
-                                        <a class="dropdown-item" href="<?php printf($link, $uuid, "block"); ?>"><?php sn_e("Block User"); ?></a>
-                                    <?php } ?>
-                                </div>
-                            </div>
+                        <td class="contentTools pt-3 text-center d-sm-table-cell">
+                            <a class="text-secondary d-none d-md-inline" href="<?php echo DOMAIN_ADMIN; ?>snicker?view=user&user=<?php echo $uuid; ?>"><i class="fa fa-comments"></i><?php sn_e("Comments"); ?></a>
+                            <?php if ($user["blocked"]) { ?>
+                                <a class="text-secondary d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "unblock"); ?>"><i class="fa fa-unlock"></i><?php sn_e("Unblock"); ?></a>
+                            <?php } else { ?>
+                                <a class="text-secondary d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "block"); ?>"><i class="fa fa-lock"></i><?php sn_e("Block"); ?></a>
+                            <?php } ?>
+                            <a class="text-secondary d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=true"><i class="fa fa-user-times"></i><?php sn_e("Anonymize"); ?></a>
+                            <a class="text-danger d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=false"><i class="fa fa-trash-o"></i><?php sn_e("Delete"); ?></a>
                         </td>
                     </tr>
                 <?php } ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -25,31 +25,35 @@ $strings = array(
     "approved" => sn__("Approved"),
     "rejected" => sn__("Rejected"),
     "spam" => sn__("Spam"),
-    "search" => sn__("Search Comments"),
     "single" => sn__("Single Comment"),
     "uuid" => sn__("Page Comments"),
-    "user" => sn__("User Comments")
+    "user" => sn__("User Comments"),
+    "users" => sn__("Users"),
+    "configure" => sn__("Configuration")
 );
 
 // Current Tab
 $view = "index";
-if (isset($_GET["view"]) && in_array($_GET["view"], array("search", "single", "uuid", "user"))) {
+$commentTabs = array("pending", "approved", "rejected", "spam");
+$adminTabs = array("users", "configure");
+$tabs = $commentTabs;
+$current = isset($_GET["tab"]) ? $_GET["tab"] : "pending";
+if (!in_array($current, array_merge($commentTabs, $adminTabs))) {
+    $current = "pending";
+}
+if (isset($_GET["view"]) && in_array($_GET["view"], array("single", "uuid", "user"))) {
     $view = $current = $_GET["view"];
-    $tabs = array($view);
-} else {
-    $current = isset($_GET["tab"]) ? $_GET["tab"] : "pending";
-    $tabs = array("pending", "approved", "rejected", "spam");
 }
 ?>
 <h2 class="mt-0 mb-3">
-    <span class="oi oi-comment-square" style="font-size: 0.7em;"></span> Snicker <?php sn_e("Comments"); ?>
+    <span class="fa fa-comments-o" style="font-size: 0.7em;"></span> Snicker <?php sn_e("Comments"); ?>
 </h2>
 
-<ul class="nav nav-pills" data-handle="tabs">
+<ul class="nav nav-tabs" role="tablist">
     <?php foreach ($tabs as $tab) { ?>
         <?php $class = "nav-link nav-{$tab}" . ($current === $tab ? " active" : ""); ?>
         <li class="nav-item">
-            <a id="<?php echo $tab; ?>-tab" href="#snicker-<?php echo $tab; ?>" class="<?php echo $class; ?>" data-toggle="tab">
+            <a id="<?php echo $tab; ?>-tab" href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=<?php echo $tab; ?>" class="<?php echo $class; ?>" role="tab">
                 <?php
                 echo $strings[$tab];
                 if ($tab === "pending" && !empty($count)) {
@@ -63,16 +67,14 @@ if (isset($_GET["view"]) && in_array($_GET["view"], array("search", "single", "u
         </li>
     <?php } ?>
 
-    <li class="nav-item flex-grow-1"></li>
-
-    <li class="nav-item mr-2">
-        <a id="users-tab" href="#snicker-users" class="nav-link nav-config" data-toggle="tab">
-            <span class="oi oi-people"></span> <?php sn_e("Users"); ?>
+    <li class="nav-item">
+        <a id="users-tab" href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=users" class="nav-link nav-users<?php echo ($current === "users") ? " active" : ""; ?>" role="tab">
+            <span class="fa fa-users"></span><?php sn_e("Users"); ?>
         </a>
     </li>
     <li class="nav-item">
-        <a id="configure-tab" href="#snicker-configure" class="nav-link nav-config" data-toggle="tab">
-            <span class="oi oi-cog"></span> <?php sn_e("Configuration"); ?>
+        <a id="configure-tab" href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=configure" class="nav-link nav-config<?php echo ($current === "configure") ? " active" : ""; ?>" role="tab">
+            <span class="fa fa-gear"></span><?php sn_e("Configuration"); ?>
         </a>
     </li>
 </ul>

--- a/plugin.php
+++ b/plugin.php
@@ -610,7 +610,7 @@ class SnickerPlugin extends Plugin
      */
     public function beforeAdminLoad()
     {
-        global $url;
+        global $layout, $url;
 
         // Check if the current View is the "snicker"
         if (strpos($url->slug(), "snicker") !== 0) {
@@ -625,6 +625,42 @@ class SnickerPlugin extends Plugin
         } else {
             $this->backendView = "index";
         }
+
+        // Render Snicker inside Bludit's normal admin theme shell.
+        $layout["plugin"] = $this;
+        $layout["view"] = "plugin-snicker";
+        $layout["title"] = "Snicker Comments - " . $layout["title"];
+    }
+
+    /*
+     |  HOOK :: ADMIN CONTROLLER
+     |  @since  1.0.1
+     */
+    public function adminController()
+    {
+        global $layout;
+
+        $layout["view"] = "plugin-snicker";
+    }
+
+    /*
+     |  HOOK :: ADMIN VIEW
+     |  @since  1.0.1
+     */
+    public function adminView()
+    {
+        if (!$this->backend || !$this->backendView) {
+            return false;
+        }
+
+        $file = SNICKER_PATH . "admin" . DS . "{$this->backendView}.php";
+        if (!file_exists($file)) {
+            return false;
+        }
+
+        ob_start();
+        require $file;
+        return ob_get_clean();
     }
 
     /*
@@ -709,10 +745,7 @@ class SnickerPlugin extends Plugin
      */
     public function adminBodyBegin()
     {
-        if (!$this->backend || !$this->backendView) {
-            return false;
-        }
-        ob_start();
+        return false;
     }
 
     /*
@@ -757,24 +790,7 @@ class SnickerPlugin extends Plugin
             return false;
         }
 
-        // Fetch Content
-        $content = ob_get_contents();
-        ob_end_clean();
-
-        // Snicker Admin Content
-        ob_start();
-        if (file_exists(SNICKER_PATH . "admin" . DS . "{$this->backendView}.php")) {
-            require SNICKER_PATH . "admin" . DS . "{$this->backendView}.php";
-            $add = ob_get_contents();
-        }
-        ob_end_clean();
-
-        // Inject Code
-        if (isset($add) && !empty($add)) {
-            $regexp = "#(\<div class=\"col-lg-10 pt-3 pb-1 h-100\"\>)(.*?)(\<\/div\>)#s";
-            $content = preg_replace($regexp, "$1{$add}$3", $content);
-        }
-        print ($content);
+        return false;
     }
 
     /*
@@ -791,7 +807,7 @@ class SnickerPlugin extends Plugin
         ob_start();
         ?>
         <a href="<?php echo HTML_PATH_ADMIN_ROOT; ?>snicker" class="nav-link" style="white-space: nowrap;">
-            <span class="oi oi-comment-square"></span>Snicker <?php sn_e("Comments"); ?>
+            <span class="fa fa-comments-o"></span>Snicker <?php sn_e("Comments"); ?>
             <?php if (!empty($count)) { ?>
                 <span class="badge badge-success badge-pill"><?php echo $count; ?></span>
             <?php } ?>

--- a/system/class.comments-index.php
+++ b/system/class.comments-index.php
@@ -351,13 +351,17 @@ class CommentsIndex extends dbJSON
      |  @param  string  The string to be searched.
      |  @param  int     The current comment page number, starting with 1.
      |  @param  int     The number of comments to be shown per page.
+     |  @param  string  Optional status to limit the search.
      |
      |  @return array   The respective unique comment IDs as ARRAY, FALSE on failure.
      */
-    public function searchComments($search, $page = 1, $limit = -1)
+    public function searchComments($search, $page = 1, $limit = -1, $status = null)
     {
         $list = array();
         foreach ($this->db as $key => $value) {
+            if ($status !== null && (!isset($value["status"]) || $value["status"] !== $status)) {
+                continue;
+            }
             if (isset($value["title"]) && stripos($value["title"], $search) !== false) {
                 $list[] = $key;
             } else if (isset($value["excerpt"]) && stripos($value["excerpt"], $search) !== false) {

--- a/system/class.comments-users.php
+++ b/system/class.comments-users.php
@@ -174,10 +174,10 @@ class CommentsUsers extends dbJSON
         if ($search !== null) {
             $list = array();
             foreach ($this->db as $uuid => $fields) {
-                if (stripos($fields["username"], $search) === false) {
-                    continue;
-                }
-                if (stripos($fields["email"], $search) === false) {
+                if (
+                    stripos($fields["username"], $search) === false &&
+                    stripos($fields["email"], $search) === false
+                ) {
                     continue;
                 }
                 $list[$uuid] = $fields;


### PR DESCRIPTION
## Summary

This PR updates the Snicker Plus admin screens to use more of Bludit's built-in admin UI patterns and to make the comment/user management views more predictable.

## Changes and UX rationale

### Render Snicker inside the standard Bludit admin shell

Snicker previously injected its admin content into the admin page output with a regex. In my local Bludit 3.17.2 install, this was fragile compared with using the admin theme's normal plugin view flow.

This PR switches Snicker to Bludit's normal plugin admin view path so the page title, sidebar, admin shell, and plugin content are rendered through the expected layout mechanism.

Rationale: this should make the plugin admin screen less dependent on the exact admin HTML structure used by a particular Bludit release.

### Use server-rendered tabs for admin state

The moderation, users, and configuration navigation now uses Bludit's established `nav-tabs` pattern with server-rendered `?tab=...` URLs.

Rationale: in newer Bludit admin UI testing, the previous client/hash-driven tab behavior could stop working predictably. In some search states, the moderation tabs could disappear entirely or the selected tab would not match the rendered content. Making the selected tab explicit in the URL keeps the page state reliable after navigation, search, pagination, and reloads.

### Remove hash-based admin tab navigation

Admin tabs no longer use `#snicker-*` anchors.

Rationale: once tab state is server-rendered, the anchors are unnecessary and can cause unwanted scroll jumps, especially when opening the Configuration tab.

### Make search state tab-specific and server-rendered

Comment moderation searches now use `commentSearch`, user searches use `userSearch`, and both are scoped to the active tab.

Rationale: the previous shared `search` parameter could leak a user search into comment search UI, or replace the moderation tabs with a single search view. Keeping search state server-rendered and tab-specific makes the URL, selected tab, search box, and empty state agree with each other.

### Scope comment search to the selected moderation status

`CommentsIndex::searchComments()` now accepts an optional status filter.

Rationale: searching from Pending, Approved, Rejected, or Spam should return results from that moderation state only. This keeps moderation workflows predictable and avoids a hidden cross-status search mode.

### Improve user search matching

User search now matches username OR email instead of requiring both to match.

Rationale: admins commonly search by whichever identifier they have available. Searching for an email fragment should not fail just because the username does not also contain that term.

### Add clear actions for active searches

Search forms show a clear icon when a search is active.

Rationale: admins need an obvious way to return to the unfiltered tab list without editing the URL manually.

### Simplify search controls

Search controls were removed from card containers and now use compact icon buttons with consistent sizing.

Rationale: this better matches the surrounding Bludit admin interfaces, where controls are presented as lightweight page tools rather than separate card-like panels. Matching input/button heights and using icon actions keeps the search row compact and consistent with the host admin UI.

### Use Bludit-style empty states

Empty messages now follow the selected tab and search state, such as:

- `There are no pending comments at this moment.`
- `There are no pending comments matching "term".`
- `There are no users matching "term".`

Rationale: empty states should explain the current view, especially when filters are active.

### Use Bludit's native admin table style

Comment and user tables now use Bludit's standard `table mt-3` structure, borderless headers, and `contentTools` action cells.

Rationale: plugin tables should feel like part of the Bludit admin, not a separate interface. This also makes row density and action placement more consistent with the Content screen.

### Align row actions with Bludit conventions

Dropdown action buttons were replaced with inline icon/text actions. Destructive Delete actions remain red; non-destructive actions such as Anonymize use neutral styling.

Rationale: row actions in Bludit's admin are visible inline, not hidden behind dropdowns. Keeping only the destructive action red makes the risk hierarchy clearer.

### Add a working sidebar icon

The Snicker sidebar item now uses a Font Awesome comment icon.

Rationale: the active Bludit admin icon set is Font Awesome, so using that library avoids a missing icon in the plugin navigation.

## Validation

- Tested locally with Bludit 3.17.2.
- Ran PHP syntax checks on touched PHP files:
  - `plugin.php`
  - `admin/index.php`
  - `admin/index-comments.php`
  - `admin/index-users.php`
  - `admin/index-config.php`
  - `system/class.comments-index.php`
  - `system/class.comments-users.php`
- Manually checked the admin UI in a local Bludit install:
  - moderation tabs remain visible during comment search
  - user search does not affect comment search
  - tab clicks clear search state
  - configuration tab no longer scrolls down on load
  - user pagination works for full lists and filtered results
  - search controls have matching heights
  - comment and user tables visually match Bludit admin table conventions
  - row action icons and labels stay together
