### PR TITLE
Improve settings page usability

### DIFF
--- a/admin/css/admin.snicker.css
+++ b/admin/css/admin.snicker.css
@@ -142,6 +142,33 @@
 }
 /* @end Admin Navigation */
 
+/* @start Admin Configuration */
+.snicker-settings-form .form-group.row {
+    margin-bottom: 1rem;
+}
+
+.snicker-settings-form .form-control,
+.snicker-settings-form .custom-select {
+    width: 100%;
+    max-width: none;
+}
+
+.snicker-settings-form .form-control,
+.snicker-settings-form .custom-select:not(.custom-select-sm) {
+    min-height: calc(1.5em + .75rem + 2px);
+}
+
+.snicker-settings-form .snicker-select-inline {
+    width: auto;
+    max-width: 100%;
+    vertical-align: top;
+}
+
+.snicker-config-actions {
+    border-bottom: 1px solid transparent;
+}
+/* @end Admin Configuration */
+
 /* @start Admin Pagination */
 .snicker-btn-group-pagination .snicker-btn {
     width: 34px;

--- a/admin/css/admin.snicker.css
+++ b/admin/css/admin.snicker.css
@@ -19,6 +19,47 @@
 }
 /* @end GENERAL */
 
+/* @start Admin Search */
+.snicker-search-row {
+    --snicker-search-control-size: 3.25rem;
+}
+
+.snicker-search-row .snicker-search-control {
+    min-width: 320px;
+    height: var(--snicker-search-control-size) !important;
+    min-height: var(--snicker-search-control-size);
+    box-sizing: border-box;
+}
+
+.snicker-search-row .snicker-search-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--snicker-search-control-size);
+    height: var(--snicker-search-control-size) !important;
+    min-height: var(--snicker-search-control-size);
+    padding: 0 !important;
+    line-height: 1;
+    box-sizing: border-box;
+}
+
+.snicker-search-row .snicker-search-button .fa {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1em;
+    height: 1em;
+    margin-right: 0 !important;
+    line-height: 1;
+}
+/* @end Admin Search */
+
+/* @start Admin Tables */
+.tab-content .contentTools a {
+    white-space: nowrap;
+}
+/* @end Admin Tables */
+
 /* @start Admin Navigation */
 .nav.nav-pills .snicker-nav-link {
     color: #343a40;

--- a/admin/index-comments.php
+++ b/admin/index-comments.php
@@ -20,11 +20,12 @@ $limit = $SnickerPlugin->getValue("frontend_per_page");
 if ($limit === 0) {
     $limit = 15;
 }
-$current = isset($_GET["tab"]) ? $_GET["tab"] : "pending";
+$current = isset($current) ? $current : (isset($_GET["tab"]) ? $_GET["tab"] : "pending");
+$commentSearch = isset($_GET["commentSearch"]) ? trim($_GET["commentSearch"]) : "";
 
 // Get View
 $view = "index";
-if (isset($_GET["view"]) && in_array($_GET["view"], array("search", "single", "uuid", "user"))) {
+if (isset($_GET["view"]) && in_array($_GET["view"], array("single", "uuid", "user"))) {
     $view = $current = $_GET["view"];
     $tabs = array($view);
 } else {
@@ -40,12 +41,13 @@ foreach ($tabs as $status) {
     }
 
     // Get Comments
-    if ($view === "index") {
+    $isFiltered = ($view === "index" && $current === $status && $commentSearch !== "");
+    if ($isFiltered) {
+        $comments = $SnickerIndex->searchComments($commentSearch, $page, $limit, $status);
+        $total = count($SnickerIndex->searchComments($commentSearch, 1, -1, $status));
+    } else if ($view === "index") {
         $comments = $SnickerIndex->getList($status, $page, $limit);
         $total = $SnickerIndex->count($status);
-    } else if ($view === "search") {
-        $comments = $SnickerIndex->searchComments(isset($_GET["search"]) ? $_GET["search"] : "");
-        $total = count($comments);
     } else if ($view === "single") {
         $comments = $SnickerIndex->getListByParent(isset($_GET["single"]) ? $_GET["single"] : "");
         $total = count($comments);
@@ -58,74 +60,72 @@ foreach ($tabs as $status) {
     }
 
     // Render Tab Content
-    $link = DOMAIN_ADMIN . "snicker?page=%d&tab={$status}#{$status}";
+    $link = DOMAIN_ADMIN . "snicker?page=%d&tab={$status}";
+    if ($isFiltered) {
+        $link .= "&commentSearch=" . urlencode($commentSearch);
+    }
     ?>
-    <div id="snicker-<?php echo $status; ?>" class="tab-pane <?php echo ($current === $status) ? "active" : ""; ?>">
-        <div class="card shadow-sm" style="margin: 1.5rem 0;">
-            <div class="card-body">
-                <div class="row">
-                    <form class="col-sm-6" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker">
-                        <div class="form-row align-items-center">
-                            <div class="col-sm-8">
-                                <?php $search = isset($_GET["search"]) ? $_GET["search"] : ""; ?>
-                                <input type="text" name="search" value="<?php echo $search; ?>" class="form-control" placeholder="<?php sn_e("Comment Title or Excerpt"); ?>" />
-                            </div>
-                            <div class="col-sm-4">
-                                <button class="btn btn-primary" name="view" value="search"><?php sn_e("Search Comments"); ?></button>
-                            </div>
-                        </div>
-                    </form>
+    <div id="snicker-<?php echo $status; ?>" class="tab-pane <?php echo ($current === $status) ? "show active" : ""; ?>" role="tabpanel">
+        <div class="snicker-search-row d-flex align-items-center flex-wrap mt-4 mb-4">
+            <form class="form-inline flex-nowrap mr-3 mb-2" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker">
+                <input type="hidden" name="tab" value="<?php echo $status; ?>" />
+                <input type="text" name="commentSearch" value="<?php echo ($current === $status) ? Sanitize::html($commentSearch) : ""; ?>" class="snicker-search-control form-control mr-2" placeholder="<?php sn_e("Comment Title or Excerpt"); ?>" />
+                <?php if ($isFiltered) { ?>
+                    <a href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=<?php echo $status; ?>" class="snicker-search-button btn btn-secondary mr-2" title="<?php sn_e("Clear"); ?>" aria-label="<?php sn_e("Clear"); ?>">
+                        <span class="fa fa-times"></span>
+                    </a>
+                <?php } ?>
+                <button class="snicker-search-button btn btn-primary" type="submit" title="<?php sn_e("Search Comments"); ?>" aria-label="<?php sn_e("Search Comments"); ?>">
+                    <span class="fa fa-search"></span>
+                </button>
+            </form>
 
-                    <div class="col-sm-6 text-right">
-                        <?php if ($total > $limit) { ?>
-                            <div class="btn-group btn-group-pagination">
-                                <?php if ($page <= 1) { ?>
-                                    <span class="btn btn-secondary disabled">&laquo;</span>
-                                    <span class="btn btn-secondary disabled">&lsaquo;</span>
-                                <?php } else { ?>
-                                    <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
-                                    <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
-                                <?php } ?>
-                                <?php if (($page * $limit) < $total) { ?>
-                                    <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
-                                    <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
-                                <?php } else { ?>
-                                    <span class="btn btn-secondary disabled">&rsaquo;</span>
-                                    <span class="btn btn-secondary disabled">&raquo;</span>
-                                <?php } ?>
-                            </div>
+            <div class="ml-auto mb-2">
+                <?php if ($limit !== -1 && $total > $limit) { ?>
+                    <div class="btn-group btn-group-pagination">
+                        <?php if ($page <= 1) { ?>
+                            <span class="btn btn-secondary disabled">&laquo;</span>
+                            <span class="btn btn-secondary disabled">&lsaquo;</span>
+                        <?php } else { ?>
+                            <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
+                            <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
+                        <?php } ?>
+                        <?php if (($page * $limit) < $total) { ?>
+                            <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
+                            <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
+                        <?php } else { ?>
+                            <span class="btn btn-secondary disabled">&rsaquo;</span>
+                            <span class="btn btn-secondary disabled">&raquo;</span>
                         <?php } ?>
                     </div>
-                </div>
+                <?php } ?>
             </div>
         </div>
 
         <?php /* No Comments available */ ?>
         <?php if (count($comments) < 1) { ?>
-            <div class="row justify-content-md-center">
-                <div class="col-sm-6">
-                    <div class="card w-100 shadow-sm bg-light">
-                        <div class="card-body text-center p-4"><i><?php sn_e("No Comments available"); ?></i></div>
-                    </div>
-                </div>
-            </div>
+            <p class="mt-4 text-muted">
+                <?php if ($isFiltered) { ?>
+                    <?php sn_e("There are no %s comments matching \"%s\".", array(strtolower($strings[$status]), Sanitize::html($commentSearch))); ?>
+                <?php } else { ?>
+                    <?php sn_e("There are no %s comments at this moment.", array(strtolower($strings[$status]))); ?>
+                <?php } ?>
+            </p>
         </div>
         <?php continue; ?>
     <?php } ?>
 
     <?php /* Comments Table */ ?>
     <?php $link = DOMAIN_ADMIN . "snicker?action=snicker&snicker=%s&uid=%s&status=%s&tokenCSRF=" . $security->getTokenCSRF(); ?>
-    <table class="table table-bordered table-hover-light shadow-sm mt-3">
-        <?php foreach (array("thead", "tfoot") as $tag) { ?>
-            <<?php echo $tag; ?>>
-                <tr class="thead-light">
-                    <th width="56%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("Comment"); ?></th>
-                    <th width="22%" class="border-0 p-3 text-uppercase text-muted text-center"><?php sn_e("Author"); ?></th>
-                    <th width="22%" class="border-0 p-3 text-uppercase text-muted text-center"><?php sn_e("Actions"); ?></th>
-                </tr>
-            </<?php echo $tag; ?>>
-        <?php } ?>
-        <tbody class="shadow-sm-both">
+    <table class="table mt-3">
+        <thead>
+            <tr>
+                <th class="border-0" scope="col"><?php sn_e("Comment"); ?></th>
+                <th class="border-0 d-none d-lg-table-cell" scope="col"><?php sn_e("Author"); ?></th>
+                <th class="border-0 text-center d-sm-table-cell" scope="col"><?php sn_e("Actions"); ?></th>
+            </tr>
+        </thead>
+        <tbody>
             <?php foreach ($comments as $uid) { ?>
                 <?php
                 $data = $SnickerIndex->getComment($uid, $status);
@@ -135,51 +135,52 @@ foreach ($tabs as $status) {
                 $user = $SnickerUsers->getByString($data["author"]);
                 ?>
                 <tr>
-                    <td class="pt-3 pb-3 pl-3 pr-3">
-                        <?php
-                        if ($SnickerPlugin->getValue("comment_title") !== "disabled" && !empty($data["title"])) {
-                            echo '<b class="d-inline-block">' . $data["title"] . '</b>';
-                        }
-                        echo '<p class="text-muted m-0" style="font-size:12px;">' . (isset($data["excerpt"]) ? $data["excerpt"] : "") . '</p>';
-                        if (!empty($data["parent_uid"]) && $SnickerIndex->exists($data["parent_uid"]) && $view !== "single") {
+                    <td class="pt-3">
+                        <div>
+                            <a style="font-size: 1.1em" href="<?php echo DOMAIN_ADMIN . "snicker/edit/?uid=" . $uid; ?>">
+                                <?php
+                                if ($SnickerPlugin->getValue("comment_title") !== "disabled" && !empty($data["title"])) {
+                                    echo $data["title"];
+                                } else {
+                                    echo sn__("Comment");
+                                }
+                                ?>
+                            </a>
+                        </div>
+                        <div>
+                            <p style="font-size: 0.8em" class="m-0 text-muted">
+                                <?php echo isset($data["excerpt"]) ? $data["excerpt"] : ""; ?>
+                            </p>
+                        </div>
+                        <?php if (!empty($data["parent_uid"]) && $SnickerIndex->exists($data["parent_uid"]) && $view !== "single") { ?>
+                            <?php
                             $reply = DOMAIN_ADMIN . "snicker?view=single&single={$uid}";
                             $reply = '<a href="' . $reply . '" title="' . sn__("Show all replies") . '">' . $SnickerIndex->getComment($data["parent_uid"])["title"] . '</a>';
-                            echo "<div class='text-muted mt-1' style='font-size:12px;'>" . sn__("Reply To") . ": " . $reply . "</div>";
-                        }
-                        ?>
+                            ?>
+                            <div class="text-muted mt-1" style="font-size: 0.8em;"><?php echo sn__("Reply To") . ": " . $reply; ?></div>
+                        <?php } ?>
                     </td>
-                    <td class="align-middle pt-2 pb-2 pl-3 pr-3">
+                    <td class="pt-3 d-none d-lg-table-cell">
                         <span class="d-inline-block"><?php echo $user["username"]; ?></span>
-                        <small class='d-block'><?php echo $user["email"]; ?></small>
+                        <p style="font-size: 0.8em" class="m-0 text-muted"><?php echo $user["email"]; ?></p>
                     </td>
-                    <td class="text-center align-middle pt-2 pb-2 pl-1 pr-1">
-                        <div class="btn-group">
-                            <button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
-                                <?php sn_e("Change"); ?>
-                            </button>
-                            <div class="dropdown-menu dropdown-menu-right">
-                                <a class="dropdown-item text-primary" href="<?php echo DOMAIN_ADMIN . "snicker/edit/?uid=" . $uid; ?>"><?php sn_e("Edit Comment"); ?></a>
-                                <a class="dropdown-item text-danger" href="<?php printf($link, "delete", $uid, "delete"); ?>"><?php sn_e("Delete Comment"); ?></a>
-                                <div class="dropdown-divider"></div>
-
-                                <?php if ($status !== "approved") { ?>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "approved"); ?>"><?php sn_e("Approve Comment"); ?></a>
-                                <?php } ?>
-                                <?php if ($status !== "rejected") { ?>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "rejected"); ?>"><?php sn_e("Reject Comment"); ?></a>
-                                <?php } ?>
-                                <?php if ($status !== "spam") { ?>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "spam"); ?>"><?php sn_e("Mark as Spam"); ?></a>
-                                <?php } ?>
-                                <?php if ($status !== "pending") { ?>
-                                    <div class="dropdown-divider"></div>
-                                    <a class="dropdown-item" href="<?php printf($link, "moderate", $uid, "pending"); ?>"><?php sn_e("Back to Pending"); ?></a>
-                                <?php } ?>
-                            </div>
-                        </div>
-
+                    <td class="contentTools pt-3 text-center d-sm-table-cell">
                         <?php $page = new Page($pages->getByUUID($data["page_uuid"])); ?>
-                        <a href="<?php echo $page->permalink(); ?>#comment-<?php echo $uid; ?>" class="btn btn-outline-primary btn-sm" target="_blank"><?php sn_e("View"); ?></a>
+                        <a class="text-secondary d-none d-md-inline" href="<?php echo $page->permalink(); ?>#comment-<?php echo $uid; ?>" target="_blank"><i class="fa fa-desktop"></i><?php sn_e("View"); ?></a>
+                        <a class="text-secondary d-none d-md-inline ml-2" href="<?php echo DOMAIN_ADMIN . "snicker/edit/?uid=" . $uid; ?>"><i class="fa fa-edit"></i><?php sn_e("Edit"); ?></a>
+                        <?php if ($status !== "approved") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "approved"); ?>"><i class="fa fa-check"></i><?php sn_e("Approve"); ?></a>
+                        <?php } ?>
+                        <?php if ($status !== "rejected") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "rejected"); ?>"><i class="fa fa-ban"></i><?php sn_e("Reject"); ?></a>
+                        <?php } ?>
+                        <?php if ($status !== "spam") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "spam"); ?>"><i class="fa fa-warning"></i><?php sn_e("Spam"); ?></a>
+                        <?php } ?>
+                        <?php if ($status !== "pending") { ?>
+                            <a class="text-secondary d-block d-lg-inline ml-lg-2" href="<?php printf($link, "moderate", $uid, "pending"); ?>"><i class="fa fa-inbox"></i><?php sn_e("Pending"); ?></a>
+                        <?php } ?>
+                        <a class="text-danger d-block d-lg-inline ml-lg-2" href="<?php printf($link, "delete", $uid, "delete"); ?>"><i class="fa fa-trash"></i><?php sn_e("Delete"); ?></a>
                     </td>
                 </tr>
             <?php } ?>

--- a/admin/index-config.php
+++ b/admin/index-config.php
@@ -18,8 +18,8 @@ global $L, $login, $pages, $security, $Snicker, $SnickerPlugin;
 $static = $pages->getStaticDB(false);
 
 ?>
-<div id="snicker-configure" class="tab-pane">
-    <form method="post" action="<?php echo HTML_PATH_ADMIN_ROOT; ?>snicker#configure">
+<div id="snicker-configure" class="tab-pane <?php echo (isset($current) && $current === "configure") ? "show active" : ""; ?>" role="tabpanel">
+    <form method="post" action="<?php echo HTML_PATH_ADMIN_ROOT; ?>snicker?tab=configure">
         <div class="card shadow-sm" style="margin: 1.5rem 0;">
             <div class="card-body">
                 <div class="row">

--- a/admin/index-config.php
+++ b/admin/index-config.php
@@ -20,32 +20,19 @@ $static = $pages->getStaticDB(false);
 ?>
 <div id="snicker-configure" class="tab-pane <?php echo (isset($current) && $current === "configure") ? "show active" : ""; ?>" role="tabpanel">
     <form method="post" action="<?php echo HTML_PATH_ADMIN_ROOT; ?>snicker?tab=configure">
-        <div class="card shadow-sm" style="margin: 1.5rem 0;">
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-sm-6">
-                        <input type="hidden" id="tokenUser" name="tokenUser" value="<?php echo $login->username(); ?>" />
-                        <input type="hidden" id="tokenCSRF" name="tokenCSRF" value="<?php echo $security->getTokenCSRF(); ?>" />
-                        <input type="hidden" id="sn-action" name="action" value="snicker" />
-                        <button class="btn btn-primary" name="snicker" value="configure"><?php sn_e("Save Settings"); ?></button>
-                    </div>
-
-                    <div class="col-sm-6">
-
-                    </div>
-                </div>
-            </div>
+        <div class="snicker-config-actions mt-3 mb-3">
+            <input type="hidden" id="tokenUser" name="tokenUser" value="<?php echo $login->username(); ?>" />
+            <input type="hidden" id="tokenCSRF" name="tokenCSRF" value="<?php echo $security->getTokenCSRF(); ?>" />
+            <input type="hidden" id="sn-action" name="action" value="snicker" />
+            <button class="btn btn-primary btn-sm" name="snicker" value="configure"><?php sn_e("Save Settings"); ?></button>
         </div>
 
-        <div class="accordion shadow-sm" id="accordion-settings">
-            <div class="card">
-                <div class="card-header text-uppercase pt-3 pb-3 pl-4 pr-4" data-toggle="collapse" data-target="#accordion-general"><?php sn_e("General Settings"); ?></div>
-                <div id="accordion-general" class="collapse show" data-parent="#accordion-settings">
-                    <div class="card-body">
+        <div class="snicker-settings-form">
+            <h6 class="mt-4 mb-2 pb-2 border-bottom text-uppercase"><?php sn_e("General Settings"); ?></h6>
                         <div class="form-group row">
                             <label for="sn-moderation" class="col-sm-3 col-form-label"><?php sn_e("Comment Moderation"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-moderation" name="moderation" class="custom-select custom-select-sm w-auto">
+                                <select id="sn-moderation" name="moderation" class="custom-select custom-select-sm snicker-select-inline">
                                     <option value="true" <?php sn_selected("moderation", true); ?>><?php sn_e("Moderate"); ?></option>
                                     <option value="false" <?php sn_selected("moderation", false); ?>><?php sn_e("Pass"); ?></option>
                                 </select>
@@ -92,7 +79,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-comment-title" class="col-sm-3 col-form-label"><?php sn_e("Comment Title"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-comment-title" name="comment_title" class="form-control custom-select">
+                                <select id="sn-comment-title" name="comment_title" class="custom-select">
                                     <option value="optional" <?php sn_selected("comment_title", "optional"); ?>><?php sn_e("Enable (Optional)"); ?></option>
                                     <option value="required" <?php sn_selected("comment_title", "required"); ?>><?php sn_e("Enable (Required)"); ?></option>
                                     <option value="disabled" <?php sn_selected("comment_title", "disabled"); ?>><?php sn_e("Disable"); ?></option>
@@ -137,7 +124,7 @@ $static = $pages->getStaticDB(false);
                             <label class="col-sm-3 col-form-label"><?php sn_e("Comment Voting"); ?></label>
                             <div class="col-sm-9">
                                 <label for="sn-vote-storage" class="col-form-label-sm mr-2 align-top"><?php sn_e("Store Votes made by Guests in the") ?></label>
-                                <select id="sn-vote-storage" name="comment_vote_storage" class="custom-select custom-select-sm w-auto">
+                                <select id="sn-vote-storage" name="comment_vote_storage" class="custom-select custom-select-sm snicker-select-inline">
                                     <option value="cookie" <?php sn_selected("comment_vote_storage", "cookie"); ?>><?php sn_e("Cookie Storage"); ?></option>
                                     <option value="session" <?php sn_selected("comment_vote_storage", "session"); ?>><?php sn_e("Session Storage"); ?></option>
                                     <option value="database" <?php sn_selected("comment_vote_storage", "database"); ?>><?php sn_e("Database Storage"); ?></option>
@@ -171,18 +158,11 @@ $static = $pages->getStaticDB(false);
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="card">
-                <div class="card-header text-uppercase pt-3 pb-3 pl-4 pr-4" data-toggle="collapse" data-target="#accordion-frontend"><?php sn_e("Frontend Settings"); ?></div>
-                <div id="accordion-frontend" class="collapse" data-parent="#accordion-settings">
-                    <div class="card-body">
+            <h6 class="mt-4 mb-2 pb-2 border-bottom text-uppercase"><?php sn_e("Frontend Settings"); ?></h6>
                         <div class="form-group row">
                             <label for="sn-filter" class="col-sm-3 col-form-label"><?php sn_e("Page Filter"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-filter" name="frontend_filter" class="form-control custom-select">
+                                <select id="sn-filter" name="frontend_filter" class="custom-select">
                                     <option value="disabled" <?php sn_selected("frontend_filter", "disabled"); ?>><?php sn_e("Disable Page Filter"); ?></option>
                                     <option value="pageBegin" <?php sn_selected("frontend_filter", "pageBegin"); ?>><?php sn_e("Use 'pageBegin'"); ?></option>
                                     <option value="pageEnd" <?php sn_selected("frontend_filter", "pageEnd"); ?>><?php sn_e("Use 'pageEnd'"); ?></option>
@@ -195,7 +175,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-captcha" class="col-sm-3 col-form-label"><?php sn_e("Comment Captcha"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-captcha" name="frontend_captcha" class="form-control custom-select">
+                                <select id="sn-captcha" name="frontend_captcha" class="custom-select">
                                     <option value="disabled" <?php sn_selected("frontend_captcha", "disabled"); ?>><?php sn_e("Disable Captcha"); ?></option>
                                     <option value="purecaptcha" <?php sn_selected("frontend_captcha", "purecaptcha"); ?>><?php sn_e("Use OWASP's PureCaptcha"); ?></option>
                                     <?php if (function_exists("imagettfbbox")) { ?>
@@ -211,7 +191,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-template" class="col-sm-3 col-form-label"><?php sn_e("Comment Template"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-template" name="frontend_template" class="form-control custom-select">
+                                <select id="sn-template" name="frontend_template" class="custom-select">
                                     <?php
                                     foreach ($Snicker->themes as $key => $theme) {
                                         ?>
@@ -226,7 +206,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-order" class="col-sm-3 col-form-label"><?php sn_e("Comment Order"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-order" name="frontend_order" class="form-control custom-select">
+                                <select id="sn-order" name="frontend_order" class="custom-select">
                                     <option value="date_desc" <?php sn_selected("frontend_order", "date_desc"); ?>><?php sn_e("Newest Comments First"); ?></option>
                                     <option value="date_asc" <?php sn_selected("frontend_order", "date_asc"); ?>><?php sn_e("Oldest Comments First"); ?></option>
                                 </select>
@@ -234,9 +214,9 @@ $static = $pages->getStaticDB(false);
                         </div>
 
                         <div class="form-group row">
-                            <label for="sn-order" class="col-sm-3 col-form-label"><?php sn_e("Comment Form Position"); ?></label>
+                            <label for="sn-form-position" class="col-sm-3 col-form-label"><?php sn_e("Comment Form Position"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-order" name="frontend_form" class="form-control custom-select">
+                                <select id="sn-form-position" name="frontend_form" class="custom-select">
                                     <option value="top" <?php sn_selected("frontend_form", "top"); ?>><?php sn_e("Show Comment Form above Comments"); ?></option>
                                     <option value="bottom" <?php sn_selected("frontend_form", "bottom"); ?>><?php sn_e("Show Comment Form below Comments"); ?></option>
                                 </select>
@@ -247,7 +227,7 @@ $static = $pages->getStaticDB(false);
                             <label for="sn-per-page" class="col-sm-3 col-form-label"><?php sn_e("Comments Per Page"); ?></label>
                             <div class="col-sm-9">
                                 <input type="number" id="sn-per-page" name="frontend_per_page" value="<?php echo sn_config("frontend_per_page"); ?>"
-                                       class="form-control" min="0" step="1" placheolder="<?php sn_e("Use '0' to show all available comments!"); ?>" />
+                                       class="form-control" min="0" step="1" placeholder="<?php sn_e("Use '0' to show all available comments!"); ?>" />
                                 <small class="form-text text-muted"><?php sn_e("Use '0' to show all available comments!"); ?></small>
                             </div>
                         </div>
@@ -255,7 +235,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-terms" class="col-sm-3 col-form-label"><?php sn_e("Terms of Use Checkbox"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-terms" name="frontend_terms" class="form-control custom-select">
+                                <select id="sn-terms" name="frontend_terms" class="custom-select">
                                     <option value="disabled" <?php sn_selected("frontend_terms", "disabled"); ?>><?php sn_e("Disable this field"); ?></option>
                                     <option value="default" <?php sn_selected("frontend_terms", "default"); ?>><?php sn_e("Show Message (See Strings)"); ?></option>
 
@@ -270,7 +250,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-ajax" class="col-sm-3 col-form-label"><?php sn_e("AJAX Script"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-ajax" name="frontend_ajax" class="form-control custom-select">
+                                <select id="sn-ajax" name="frontend_ajax" class="custom-select">
                                     <option value="true" <?php sn_selected("frontend_ajax", true); ?>><?php sn_e("Embed AJAX Script"); ?></option>
                                     <option value="false" <?php sn_selected("frontend_ajax", false); ?>><?php sn_e("Don't use AJAX"); ?></option>
                                 </select>
@@ -283,7 +263,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-avatar" class="col-sm-3 col-form-label"><?php sn_e("Comment Avatar"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-avatar" name="frontend_avatar" class="form-control custom-select">
+                                <select id="sn-avatar" name="frontend_avatar" class="custom-select">
                                     <option value="gravatar" <?php sn_selected("frontend_avatar", "gravatar"); ?>><?php sn_e("Use Gravatar"); ?></option>
                                     <option value="identicon" <?php sn_selected("frontend_avatar", "identicon"); ?>><?php sn_e("Use Identicon"); ?></option>
                                     <option value="static" <?php sn_selected("frontend_avatar", "static"); ?>><?php sn_e("Use Mystery Men"); ?></option>
@@ -300,7 +280,7 @@ $static = $pages->getStaticDB(false);
                         <div class="form-group row">
                             <label for="sn-gravatar" class="col-sm-3 col-form-label"><?php sn_e("Comment Gravatar"); ?></label>
                             <div class="col-sm-9">
-                                <select id="sn-gravatar" name="frontend_gravatar" class="form-control custom-select">
+                                <select id="sn-gravatar" name="frontend_gravatar" class="custom-select">
                                     <option value="mp" <?php sn_selected("frontend_gravatar", "mp"); ?>><?php sn_e("Show Mystery Person"); ?></option>
                                     <option value="identicon" <?php sn_selected("frontend_gravatar", "identicon"); ?>><?php sn_e("Show"); ?> Identicon</option>
                                     <option value="monsterid" <?php sn_selected("frontend_gravatar", "monsterid"); ?>><?php sn_e("Show"); ?> Monster ID</option>
@@ -309,73 +289,7 @@ $static = $pages->getStaticDB(false);
                                 <small class="form-text text-muted"><?php sn_e("The default Gravatar image, if the user has no Gravatar!"); ?></small>
                             </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="card">
-                <div class="card-header text-uppercase pt-3 pb-3 pl-4 pr-4" data-toggle="collapse" data-target="#accordion-subscripton"><?php sn_e("Subscription Settings"); ?></div>
-                <div id="accordion-subscripton" class="collapse" data-parent="#accordion-settings">
-                    <div class="card-body">
-                        <div class="alert alert-info"><?php sn_e("The Subscription system isn't available yet!"); ?> :(</div>
-                        <div class="form-group row">
-                            <label for="sn-subscription" class="col-sm-3 col-form-label text-muted"><?php sn_e("eMail Subscription"); ?></label>
-                            <div class="col-sm-9">
-                                <select id="sn-subscription" name="subscription" class="form-control custom-select" disabled="disabled">
-                                    <option value="true" <?php sn_selected("subscription", true); ?> disabled="disabled"><?php sn_e("Enable"); ?></option>
-                                    <option value="false" <?php sn_selected("subscription", false); ?>><?php sn_e("Disable"); ?></option>
-                                </select>
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="sn-subscription-from" class="col-sm-3 col-form-label text-muted"><?php sn_e("eMail 'From' Address"); ?></label>
-                            <div class="col-sm-9">
-                                <input type="text" id="sn-subscription-from" name="subscription_from" value="<?php echo sn_config("subscription_from"); ?>"
-                                       class="form-control" placeholder="<?php sn_e("eMail 'From' Address"); ?>" disabled="disabled" />
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="sn-subscription-reply" class="col-sm-3 col-form-label text-muted"><?php sn_e("eMail 'ReplyTo' Address"); ?></label>
-                            <div class="col-sm-9">
-                                <input type="text" id="sn-subscription-reply" name="subscription_reply" value="<?php echo sn_config("subscription_reply"); ?>"
-                                       class="form-control" placeholder="<?php sn_e("eMail 'ReplyTo' Address"); ?>" disabled="disabled" />
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="sn-subscription-optin" class="col-sm-3 col-form-label text-muted"><?php sn_e("eMail Body (Opt-In)"); ?></label>
-                            <div class="col-sm-9">
-                                <select id="sn-subscription-optin" name="subscription_optin" class="form-control custom-select" disabled="disabled">
-                                    <option value="default" <?php sn_selected("subscription_optin", "default"); ?>><?php sn_e("Use default Subscription eMail"); ?></option>
-                                    <?php foreach ($static as $key => $value) { ?>
-                                        <option value="<?php echo $key; ?>" <?php sn_selected("subscription_optin", $key); ?>><?php sn_e("Page"); ?>: <?php echo $value["title"]; ?></option>
-                                    <?php } ?>
-                                </select>
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="sn-subscription-ticker" class="col-sm-3 col-form-label text-muted"><?php sn_e("eMail Body (Notification)"); ?></label>
-                            <div class="col-sm-9">
-                                <select id="sn-subscription-ticker" name="subscription_ticker" class="form-control custom-select" disabled="disabled">
-                                    <option value="default" <?php sn_selected("subscription_ticker", "default"); ?>><?php sn_e("Use default Notification eMail"); ?></option>
-                                    <?php foreach ($static as $key => $value) { ?>
-                                        <option value="<?php echo $key; ?>" <?php sn_selected("subscription_ticker", $key); ?>><?php sn_e("Page"); ?>: <?php echo $value["title"]; ?></option>
-                                    <?php } ?>
-                                </select>
-                                <small class="form-text text-muted"><?php sn_e("Read more about a custom Notification eMails %s!", array('<a href="#" target="_blank">' . sn__("here") . '</a>')); ?></small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="card">
-                <div class="card-header text-uppercase pt-3 pb-3 pl-4 pr-4" data-toggle="collapse" data-target="#accordion-strings"><?php sn_e("Strings"); ?></div>
-                <div id="accordion-strings" class="collapse" data-parent="#accordion-settings">
-                    <div class="card-body">
+            <h6 class="mt-4 mb-2 pb-2 border-bottom text-uppercase"><?php sn_e("Strings"); ?></h6>
                         <div class="form-group row">
                             <label for="sn-success-1" class="col-sm-3 col-form-label"><?php sn_e("Default Thanks Message"); ?></label>
                             <div class="col-sm-9">
@@ -471,15 +385,10 @@ $static = $pages->getStaticDB(false);
                                        class="form-control" placeholder="<?php echo $SnickerPlugin->dbFields["string_terms_of_use"]; ?>" />
                             </div>
                         </div>
-                    </div>
-                </div>
-            </div>
         </div>
 
-        <div class="card shadow-sm mt-4 mb-4">
-            <div class="card-body">
-                <button class="btn btn-primary" name="snicker" value="configure"><?php sn_e("Save Settings"); ?></button>
-            </div>
+        <div class="snicker-config-actions mt-4 mb-4">
+            <button class="btn btn-primary btn-sm" name="snicker" value="configure"><?php sn_e("Save Settings"); ?></button>
         </div>
     </form>
 </div>

--- a/admin/index-users.php
+++ b/admin/index-users.php
@@ -18,113 +18,108 @@ global $SnickerUsers;
 $page = max((isset($_GET["page"]) ? (int) $_GET["page"] : 1), 1);
 $limit = sn_config("frontend_per_page");
 $total = count($SnickerUsers->db);
+$search = "";
+$isFiltered = (isset($current) && $current === "users" && isset($_GET["userSearch"]) && trim($_GET["userSearch"]) !== "");
 
 // Get Users
-$search = null;
-if (isset($_GET["view"]) && $_GET["view"] === "users") {
-    $page = 1;
-    $limit = -1;
-    $search = isset($_GET["search"]) ? $_GET["search"] : null;
+if ($isFiltered) {
+    $search = trim($_GET["userSearch"]);
+    $total = count($SnickerUsers->getList($search, 1, -1));
 }
-$users = $SnickerUsers->getList($search, $page, $limit);
+$users = $SnickerUsers->getList($isFiltered ? $search : null, $page, $limit);
 
 // Link
-$link = DOMAIN_ADMIN . "snicker?page=%d&tab=users#users";
+$link = DOMAIN_ADMIN . "snicker?page=%d&tab=users";
+if ($isFiltered) {
+    $link .= "&userSearch=" . urlencode($search);
+}
 
 ?>
-<div id="snicker-users" class="tab-pane">
-    <div class="card shadow-sm" style="margin: 1.5rem 0;">
-        <div class="card-body">
-            <div class="row">
-                <form class="col-sm-6" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker#users">
-                    <div class="form-row align-items-center">
-                        <div class="col-sm-8">
-                            <input type="text" name="search" value="<?php echo $search; ?>" class="form-control" placeholder="<?php sn_e("Username or eMail Address"); ?>" />
-                        </div>
-                        <div class="col-sm-4">
-                            <button class="btn btn-primary" name="view" value="users"><?php sn_e("Search Users"); ?></button>
-                        </div>
-                    </div>
-                </form>
+<div id="snicker-users" class="tab-pane <?php echo (isset($current) && $current === "users") ? "show active" : ""; ?>" role="tabpanel">
+    <div class="snicker-search-row d-flex align-items-center flex-wrap mt-4 mb-4">
+        <form class="form-inline flex-nowrap mr-3 mb-2" method="get" action="<?php echo DOMAIN_ADMIN; ?>snicker">
+            <input type="hidden" name="tab" value="users" />
+            <input type="text" name="userSearch" value="<?php echo Sanitize::html($search); ?>" class="snicker-search-control form-control mr-2" placeholder="<?php sn_e("Username or eMail Address"); ?>" />
+            <?php if ($isFiltered) { ?>
+                <a href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=users" class="snicker-search-button btn btn-secondary mr-2" title="<?php sn_e("Clear"); ?>" aria-label="<?php sn_e("Clear"); ?>">
+                    <span class="fa fa-times"></span>
+                </a>
+            <?php } ?>
+            <button class="snicker-search-button btn btn-primary" type="submit" title="<?php sn_e("Search Users"); ?>" aria-label="<?php sn_e("Search Users"); ?>">
+                <span class="fa fa-search"></span>
+            </button>
+        </form>
 
-                <div class="col-sm-6 text-right">
-                    <?php if ($total > $limit) { ?>
-                        <div class="btn-group btn-group-pagination">
-                            <?php if ($page <= 1) { ?>
-                                <span class="btn btn-secondary disabled">&laquo;</span>
-                                <span class="btn btn-secondary disabled">&lsaquo;</span>
-                            <?php } else { ?>
-                                <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
-                                <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
-                            <?php } ?>
-                            <?php if (($page * $limit) < $total) { ?>
-                                <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
-                                <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
-                            <?php } else { ?>
-                                <span class="btn btn-secondary disabled">&rsaquo;</span>
-                                <span class="btn btn-secondary disabled">&raquo;</span>
-                            <?php } ?>
-                        </div>
+        <div class="ml-auto mb-2">
+            <?php if ($limit !== -1 && $total > $limit) { ?>
+                <div class="btn-group btn-group-pagination">
+                    <?php if ($page <= 1) { ?>
+                        <span class="btn btn-secondary disabled">&laquo;</span>
+                        <span class="btn btn-secondary disabled">&lsaquo;</span>
+                    <?php } else { ?>
+                        <a href="<?php printf($link, 1); ?>" class="btn btn-secondary">&laquo;</a>
+                        <a href="<?php printf($link, $page - 1); ?>" class="btn btn-secondary">&lsaquo;</a>
+                    <?php } ?>
+                    <?php if (($page * $limit) < $total) { ?>
+                        <a href="<?php printf($link, $page + 1); ?>" class="btn btn-secondary">&rsaquo;</a>
+                        <a href="<?php printf($link, ceil($total / $limit)); ?>" class="btn btn-secondary">&raquo;</a>
+                    <?php } else { ?>
+                        <span class="btn btn-secondary disabled">&rsaquo;</span>
+                        <span class="btn btn-secondary disabled">&raquo;</span>
                     <?php } ?>
                 </div>
-            </div>
+            <?php } ?>
         </div>
     </div>
 
     <?php if (!$users || count($users) === 0) { ?>
-        <div class="row justify-content-md-center">
-            <div class="col-sm-6">
-                <div class="card w-100 shadow-sm bg-light">
-                    <div class="card-body text-center p-4"><i><?php sn_e("No Users available"); ?></i></div>
-                </div>
-            </div>
-        </div>
+        <?php if ($isFiltered) { ?>
+            <p class="mt-4 text-muted"><?php sn_e("There are no users matching \"%s\".", array(Sanitize::html($search))); ?></p>
+        <?php } else { ?>
+            <p class="mt-4 text-muted"><?php sn_e("There are no users at this moment."); ?></p>
+        <?php } ?>
     <?php } else { ?>
         <?php $link = DOMAIN_ADMIN . "snicker?action=snicker&snicker=users&uuid=%s&handle=%s&tokenCSRF=" . $security->getTokenCSRF(); ?>
-        <table class="table table-bordered table-hover-light shadow-sm mt-3">
-            <?php foreach (array("thead", "tfoot") as $tag) { ?>
-                <<?php echo $tag; ?>>
-                    <tr class="thead-light">
-                        <th width="38%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("Username"); ?></th>
-                        <th width="15%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("eMail"); ?></th>
-                        <th width="22%" class="border-0 p-3 text-uppercase text-muted"><?php sn_e("Comments"); ?></th>
-                        <th width="25%" class="border-0 p-3 text-uppercase text-muted text-center"><?php sn_e("Actions"); ?></th>
-                    </tr>
-                </<?php echo $tag; ?>>
-            <?php } ?>
-
-            <tbody class="shadow-sm-both">
+        <table class="table mt-3">
+            <thead>
+                <tr>
+                    <th class="border-0" scope="col"><?php sn_e("Username"); ?></th>
+                    <th class="border-0 d-none d-lg-table-cell" scope="col"><?php sn_e("eMail"); ?></th>
+                    <th class="border-0 text-center d-none d-md-table-cell" scope="col"><?php sn_e("Comments"); ?></th>
+                    <th class="border-0 text-center d-sm-table-cell" scope="col"><?php sn_e("Actions"); ?></th>
+                </tr>
+            </thead>
+            <tbody>
                 <?php foreach ($users as $uuid => $user) { ?>
                     <tr>
-                        <td class="p-3">
-                            <?php echo $user["username"]; ?>
+                        <td class="pt-3">
+                            <div>
+                                <a style="font-size: 1.1em" href="<?php echo DOMAIN_ADMIN; ?>snicker?view=user&user=<?php echo $uuid; ?>">
+                                    <?php echo $user["username"]; ?>
+                                </a>
+                            </div>
+                            <div class="d-lg-none">
+                                <p style="font-size: 0.8em" class="m-0 text-muted"><?php echo $user["email"]; ?></p>
+                            </div>
                         </td>
-                        <td class="p-3">
+                        <td class="pt-3 d-none d-lg-table-cell">
                             <?php echo $user["email"]; ?>
                         </td>
-                        <td class="text-center align-middle pt-2 pb-2 pl-1 pr-1">
+                        <td class="pt-3 text-center d-none d-md-table-cell">
                             <a href="<?php echo DOMAIN_ADMIN; ?>snicker?view=user&user=<?php echo $uuid; ?>">
                                 <?php echo count(isset($user["comments"]) ? $user["comments"] : array()); ?>
                                 <?php sn_e("Comments"); ?>
                             </a>
                         </td>
-                        <td class="text-center align-middle pt-2 pb-2 pl-1 pr-1">
-                            <div class="btn-group">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
-                                    <?php sn_e("Handle"); ?>
-                                </button>
-                                <div class="dropdown-menu dropdown-menu-right">
-                                    <a class="dropdown-item text-danger" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=true"><?php sn_e("Delete (Anonymize)"); ?></a>
-                                    <a class="dropdown-item text-danger" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=false"><?php sn_e("Delete (Completely)"); ?></a>
-                                    <div class="dropdown-divider"></div>
-
-                                    <?php if ($user["blocked"]) { ?>
-                                        <a class="dropdown-item" href="<?php printf($link, $uuid, "unblock"); ?>"><?php sn_e("Unblock User"); ?></a>
-                                    <?php } else { ?>
-                                        <a class="dropdown-item" href="<?php printf($link, $uuid, "block"); ?>"><?php sn_e("Block User"); ?></a>
-                                    <?php } ?>
-                                </div>
-                            </div>
+                        <td class="contentTools pt-3 text-center d-sm-table-cell">
+                            <a class="text-secondary d-none d-md-inline" href="<?php echo DOMAIN_ADMIN; ?>snicker?view=user&user=<?php echo $uuid; ?>"><i class="fa fa-comments"></i><?php sn_e("Comments"); ?></a>
+                            <?php if ($user["blocked"]) { ?>
+                                <a class="text-secondary d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "unblock"); ?>"><i class="fa fa-unlock"></i><?php sn_e("Unblock"); ?></a>
+                            <?php } else { ?>
+                                <a class="text-secondary d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "block"); ?>"><i class="fa fa-lock"></i><?php sn_e("Block"); ?></a>
+                            <?php } ?>
+                            <a class="text-secondary d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=true"><i class="fa fa-user-times"></i><?php sn_e("Anonymize"); ?></a>
+                            <a class="text-danger d-block d-md-inline ml-md-2" href="<?php printf($link, $uuid, "delete"); ?>&anonymize=false"><i class="fa fa-trash-o"></i><?php sn_e("Delete"); ?></a>
                         </td>
                     </tr>
                 <?php } ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -25,31 +25,35 @@ $strings = array(
     "approved" => sn__("Approved"),
     "rejected" => sn__("Rejected"),
     "spam" => sn__("Spam"),
-    "search" => sn__("Search Comments"),
     "single" => sn__("Single Comment"),
     "uuid" => sn__("Page Comments"),
-    "user" => sn__("User Comments")
+    "user" => sn__("User Comments"),
+    "users" => sn__("Users"),
+    "configure" => sn__("Configuration")
 );
 
 // Current Tab
 $view = "index";
-if (isset($_GET["view"]) && in_array($_GET["view"], array("search", "single", "uuid", "user"))) {
+$commentTabs = array("pending", "approved", "rejected", "spam");
+$adminTabs = array("users", "configure");
+$tabs = $commentTabs;
+$current = isset($_GET["tab"]) ? $_GET["tab"] : "pending";
+if (!in_array($current, array_merge($commentTabs, $adminTabs))) {
+    $current = "pending";
+}
+if (isset($_GET["view"]) && in_array($_GET["view"], array("single", "uuid", "user"))) {
     $view = $current = $_GET["view"];
-    $tabs = array($view);
-} else {
-    $current = isset($_GET["tab"]) ? $_GET["tab"] : "pending";
-    $tabs = array("pending", "approved", "rejected", "spam");
 }
 ?>
 <h2 class="mt-0 mb-3">
-    <span class="oi oi-comment-square" style="font-size: 0.7em;"></span> Snicker <?php sn_e("Comments"); ?>
+    <span class="fa fa-comments-o" style="font-size: 0.7em;"></span> Snicker <?php sn_e("Comments"); ?>
 </h2>
 
-<ul class="nav nav-pills" data-handle="tabs">
+<ul class="nav nav-tabs" role="tablist">
     <?php foreach ($tabs as $tab) { ?>
         <?php $class = "nav-link nav-{$tab}" . ($current === $tab ? " active" : ""); ?>
         <li class="nav-item">
-            <a id="<?php echo $tab; ?>-tab" href="#snicker-<?php echo $tab; ?>" class="<?php echo $class; ?>" data-toggle="tab">
+            <a id="<?php echo $tab; ?>-tab" href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=<?php echo $tab; ?>" class="<?php echo $class; ?>" role="tab">
                 <?php
                 echo $strings[$tab];
                 if ($tab === "pending" && !empty($count)) {
@@ -63,16 +67,14 @@ if (isset($_GET["view"]) && in_array($_GET["view"], array("search", "single", "u
         </li>
     <?php } ?>
 
-    <li class="nav-item flex-grow-1"></li>
-
-    <li class="nav-item mr-2">
-        <a id="users-tab" href="#snicker-users" class="nav-link nav-config" data-toggle="tab">
-            <span class="oi oi-people"></span> <?php sn_e("Users"); ?>
+    <li class="nav-item">
+        <a id="users-tab" href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=users" class="nav-link nav-users<?php echo ($current === "users") ? " active" : ""; ?>" role="tab">
+            <span class="fa fa-users"></span><?php sn_e("Users"); ?>
         </a>
     </li>
     <li class="nav-item">
-        <a id="configure-tab" href="#snicker-configure" class="nav-link nav-config" data-toggle="tab">
-            <span class="oi oi-cog"></span> <?php sn_e("Configuration"); ?>
+        <a id="configure-tab" href="<?php echo DOMAIN_ADMIN; ?>snicker?tab=configure" class="nav-link nav-config<?php echo ($current === "configure") ? " active" : ""; ?>" role="tab">
+            <span class="fa fa-gear"></span><?php sn_e("Configuration"); ?>
         </a>
     </li>
 </ul>

--- a/plugin.php
+++ b/plugin.php
@@ -610,7 +610,7 @@ class SnickerPlugin extends Plugin
      */
     public function beforeAdminLoad()
     {
-        global $url;
+        global $layout, $url;
 
         // Check if the current View is the "snicker"
         if (strpos($url->slug(), "snicker") !== 0) {
@@ -625,6 +625,42 @@ class SnickerPlugin extends Plugin
         } else {
             $this->backendView = "index";
         }
+
+        // Render Snicker inside Bludit's normal admin theme shell.
+        $layout["plugin"] = $this;
+        $layout["view"] = "plugin-snicker";
+        $layout["title"] = "Snicker Comments - " . $layout["title"];
+    }
+
+    /*
+     |  HOOK :: ADMIN CONTROLLER
+     |  @since  1.0.1
+     */
+    public function adminController()
+    {
+        global $layout;
+
+        $layout["view"] = "plugin-snicker";
+    }
+
+    /*
+     |  HOOK :: ADMIN VIEW
+     |  @since  1.0.1
+     */
+    public function adminView()
+    {
+        if (!$this->backend || !$this->backendView) {
+            return false;
+        }
+
+        $file = SNICKER_PATH . "admin" . DS . "{$this->backendView}.php";
+        if (!file_exists($file)) {
+            return false;
+        }
+
+        ob_start();
+        require $file;
+        return ob_get_clean();
     }
 
     /*
@@ -709,10 +745,7 @@ class SnickerPlugin extends Plugin
      */
     public function adminBodyBegin()
     {
-        if (!$this->backend || !$this->backendView) {
-            return false;
-        }
-        ob_start();
+        return false;
     }
 
     /*
@@ -757,24 +790,7 @@ class SnickerPlugin extends Plugin
             return false;
         }
 
-        // Fetch Content
-        $content = ob_get_contents();
-        ob_end_clean();
-
-        // Snicker Admin Content
-        ob_start();
-        if (file_exists(SNICKER_PATH . "admin" . DS . "{$this->backendView}.php")) {
-            require SNICKER_PATH . "admin" . DS . "{$this->backendView}.php";
-            $add = ob_get_contents();
-        }
-        ob_end_clean();
-
-        // Inject Code
-        if (isset($add) && !empty($add)) {
-            $regexp = "#(\<div class=\"col-lg-10 pt-3 pb-1 h-100\"\>)(.*?)(\<\/div\>)#s";
-            $content = preg_replace($regexp, "$1{$add}$3", $content);
-        }
-        print ($content);
+        return false;
     }
 
     /*
@@ -791,7 +807,7 @@ class SnickerPlugin extends Plugin
         ob_start();
         ?>
         <a href="<?php echo HTML_PATH_ADMIN_ROOT; ?>snicker" class="nav-link" style="white-space: nowrap;">
-            <span class="oi oi-comment-square"></span>Snicker <?php sn_e("Comments"); ?>
+            <span class="fa fa-comments-o"></span>Snicker <?php sn_e("Comments"); ?>
             <?php if (!empty($count)) { ?>
                 <span class="badge badge-success badge-pill"><?php echo $count; ?></span>
             <?php } ?>

--- a/system/class.comments-index.php
+++ b/system/class.comments-index.php
@@ -351,13 +351,17 @@ class CommentsIndex extends dbJSON
      |  @param  string  The string to be searched.
      |  @param  int     The current comment page number, starting with 1.
      |  @param  int     The number of comments to be shown per page.
+     |  @param  string  Optional status to limit the search.
      |
      |  @return array   The respective unique comment IDs as ARRAY, FALSE on failure.
      */
-    public function searchComments($search, $page = 1, $limit = -1)
+    public function searchComments($search, $page = 1, $limit = -1, $status = null)
     {
         $list = array();
         foreach ($this->db as $key => $value) {
+            if ($status !== null && (!isset($value["status"]) || $value["status"] !== $status)) {
+                continue;
+            }
             if (isset($value["title"]) && stripos($value["title"], $search) !== false) {
                 $list[] = $key;
             } else if (isset($value["excerpt"]) && stripos($value["excerpt"], $search) !== false) {

--- a/system/class.comments-users.php
+++ b/system/class.comments-users.php
@@ -174,10 +174,10 @@ class CommentsUsers extends dbJSON
         if ($search !== null) {
             $list = array();
             foreach ($this->db as $uuid => $fields) {
-                if (stripos($fields["username"], $search) === false) {
-                    continue;
-                }
-                if (stripos($fields["email"], $search) === false) {
+                if (
+                    stripos($fields["username"], $search) === false &&
+                    stripos($fields["email"], $search) === false
+                ) {
                     continue;
                 }
                 $list[$uuid] = $fields;


### PR DESCRIPTION
## Summary

Refactor the Snicker configuration page to better match Bludit’s standard admin settings layout.

This PR is stacked on top of #3 (`admin-layout-shell`). Until #3 is merged, GitHub may show those base changes in the combined diff; the new settings-page work is the `Improve settings page usability` commit.

## Changes and UX rationale

- Replace accordion sections with a continuous settings page.
  - Rationale: Bludit’s admin settings pages present sections as a visible vertical list, which makes scanning easier and avoids hiding important settings behind non-obvious accordion behavior.

- Use Bludit-style section headings for General Settings, Frontend Settings, and Strings.
  - Rationale: Matching the native admin pattern helps users understand the page structure without learning a custom interaction model.

- Remove the inactive Subscription Settings section.
  - Rationale: Showing disabled controls for a feature that does not exist creates noise and can make users think subscriptions are partially configurable.

- Resize configuration controls to use the available form width.
  - Rationale: Longer selected values and saved text are now readable without being visually clipped.

- Fix duplicate form control IDs and a placeholder typo.
  - Rationale: Unique IDs improve label behavior and accessibility, while the corrected placeholder restores the intended browser hint text.

## Verification

- Ran `php -l admin/index-config.php`
- Ran `php -l plugin.php`
- Checked the rendered page in Bludit admin at `localhost:8000/admin/snicker?tab=configure`
- Verified against the local Bludit install version: `3.17.2`
